### PR TITLE
feat: explain the KTON staking reward phase-out

### DIFF
--- a/src/app/(defi)/layout.tsx
+++ b/src/app/(defi)/layout.tsx
@@ -12,7 +12,7 @@ const KTONPool = dynamic(() => import('@/components/kton-pool'), {
 
 const DefiLayout = ({ children }: PropsWithChildren) => {
   return (
-    <div className="flex h-full w-full items-center justify-center px-10 ">
+    <div className="flex min-h-full w-full items-center justify-center px-10 py-5">
       <PoolProvider>
         <div className="container flex flex-col items-center justify-center gap-5 rounded-[1.25rem] bg-[#242A2E] p-5 sm:w-[25rem]">
           <KTONPool />

--- a/src/app/(defi)/page.tsx
+++ b/src/app/(defi)/page.tsx
@@ -9,6 +9,7 @@ import { Separator } from '@/components/ui/separator';
 import { menuItems } from '@/config/menu';
 import KTONActionLoading from '@/components/kton-action-loading';
 import ClaimLoading from '@/components/claim-loading';
+import ClaimRewardsNotice from '@/components/claim-rewards-notice';
 import { cn } from '@/lib/utils';
 
 const Stake = dynamic(() => import('@/components/stake'), {
@@ -75,7 +76,7 @@ const DefiTabs = () => {
               value === item.key && (
                 <TabsContent key={item.key} value={item.key} className="mt-0">
                   <motion.div
-                    initial={{ opacity: 0 }}
+                    initial={false}
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
                     transition={{ duration: 0.5, ease: 'easeIn' }}
@@ -88,7 +89,10 @@ const DefiTabs = () => {
                       <UnStakes onTransactionActiveChange={setIsTransactionActive} />
                     )}
                     {value === 'claim' && (
-                      <Claim onTransactionActiveChange={setIsTransactionActive} />
+                      <>
+                        <ClaimRewardsNotice />
+                        <Claim onTransactionActiveChange={setIsTransactionActive} />
+                      </>
                     )}
                   </motion.div>
                 </TabsContent>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
             <AppProvider>
               <div className="flex h-dvh w-screen flex-col overflow-hidden lg:h-screen">
                 <Header />
-                <main className="flex-1">{children}</main>
+                <main className="min-h-0 flex-1 overflow-y-auto">{children}</main>
                 <Footer />
               </div>
               <Toaster position="top-right" duration={5000} />

--- a/src/components/claim-rewards-notice.test.tsx
+++ b/src/components/claim-rewards-notice.test.tsx
@@ -1,0 +1,18 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import ClaimRewardsNotice, { RINGDAO_REWARDS_PROPOSAL_URL } from './claim-rewards-notice';
+
+describe('ClaimRewardsNotice', () => {
+  it('explains the reward phase-out without hiding access to accrued rewards', () => {
+    const markup = renderToStaticMarkup(createElement(ClaimRewardsNotice));
+
+    expect(markup).toContain('KTON staking will no longer earn new RING rewards.');
+    expect(markup).toContain('Claim remains available for rewards already earned.');
+    expect(markup).toContain(`href="${RINGDAO_REWARDS_PROPOSAL_URL}"`);
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain('rel="noopener noreferrer"');
+    expect(markup).toContain('aria-labelledby="claim-rewards-notice-title"');
+  });
+});

--- a/src/components/claim-rewards-notice.test.tsx
+++ b/src/components/claim-rewards-notice.test.tsx
@@ -2,7 +2,7 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import ClaimRewardsNotice, { RINGDAO_REWARDS_PROPOSAL_URL } from './claim-rewards-notice';
+import ClaimRewardsNotice, { KTONDAO_REWARDS_PROPOSAL_URL } from './claim-rewards-notice';
 
 describe('ClaimRewardsNotice', () => {
   it('explains the reward phase-out without hiding access to accrued rewards', () => {
@@ -10,7 +10,10 @@ describe('ClaimRewardsNotice', () => {
 
     expect(markup).toContain('KTON staking will no longer earn new RING rewards.');
     expect(markup).toContain('Claim remains available for rewards already earned.');
-    expect(markup).toContain(`href="${RINGDAO_REWARDS_PROPOSAL_URL}"`);
+    expect(KTONDAO_REWARDS_PROPOSAL_URL).toBe(
+      'https://gov.ktondao.xyz/proposal/0xb20b4feabca368f82aa819edce05e65a20d8ebbd998f0681143bbe6958052469'
+    );
+    expect(markup).toContain(`href="${KTONDAO_REWARDS_PROPOSAL_URL}"`);
     expect(markup).toContain('target="_blank"');
     expect(markup).toContain('rel="noopener noreferrer"');
     expect(markup).toContain('aria-labelledby="claim-rewards-notice-title"');

--- a/src/components/claim-rewards-notice.tsx
+++ b/src/components/claim-rewards-notice.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { ExternalLink } from 'lucide-react';
 
-export const RINGDAO_REWARDS_PROPOSAL_URL =
-  'https://gov.ringdao.com/proposal/0xf26faca1125af8f9813c5d88fecf533aa11d5a1b4f9b6dcd131c90206156dd1d';
+export const KTONDAO_REWARDS_PROPOSAL_URL =
+  'https://gov.ktondao.xyz/proposal/0xb20b4feabca368f82aa819edce05e65a20d8ebbd998f0681143bbe6958052469';
 
 const ClaimRewardsNotice = () => {
   return (
@@ -18,10 +18,10 @@ const ClaimRewardsNotice = () => {
           REWARD UPDATE
         </h2>
         <a
-          href={RINGDAO_REWARDS_PROPOSAL_URL}
+          href={KTONDAO_REWARDS_PROPOSAL_URL}
           target="_blank"
           rel="noopener noreferrer"
-          aria-label="View the RingDAO governance proposal about KTON staking rewards (opens in a new tab)"
+          aria-label="View the KtonDAO governance proposal about KTON staking rewards (opens in a new tab)"
           className="inline-flex shrink-0 items-center gap-1 text-[0.625rem] font-bold leading-4 text-white/60 underline decoration-white/30 underline-offset-4 transition-colors hover:text-primary hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70"
         >
           VIEW PROPOSAL

--- a/src/components/claim-rewards-notice.tsx
+++ b/src/components/claim-rewards-notice.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { ExternalLink } from 'lucide-react';
+
+export const RINGDAO_REWARDS_PROPOSAL_URL =
+  'https://gov.ringdao.com/proposal/0xf26faca1125af8f9813c5d88fecf533aa11d5a1b4f9b6dcd131c90206156dd1d';
+
+const ClaimRewardsNotice = () => {
+  return (
+    <aside
+      aria-labelledby="claim-rewards-notice-title"
+      className="rounded-[0.3125rem] border border-l-2 border-white/10 border-l-primary bg-[#1A1D1F]/70 px-3.5 py-3"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2
+          id="claim-rewards-notice-title"
+          className="text-[0.625rem] font-bold leading-4 tracking-[0.08em] text-primary"
+        >
+          REWARD UPDATE
+        </h2>
+        <a
+          href={RINGDAO_REWARDS_PROPOSAL_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="View the RingDAO governance proposal about KTON staking rewards (opens in a new tab)"
+          className="inline-flex shrink-0 items-center gap-1 text-[0.625rem] font-bold leading-4 text-white/60 underline decoration-white/30 underline-offset-4 transition-colors hover:text-primary hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70"
+        >
+          VIEW PROPOSAL
+          <ExternalLink aria-hidden="true" className="size-3" strokeWidth={2} />
+        </a>
+      </div>
+      <p className="mt-2 text-[0.6875rem] leading-[1.125rem]">
+        <span className="font-bold text-white">
+          KTON staking will no longer earn new RING rewards.
+        </span>{' '}
+        <span className="text-white/60">Claim remains available for rewards already earned.</span>
+      </p>
+    </aside>
+  );
+};
+
+export default ClaimRewardsNotice;


### PR DESCRIPTION
## Summary

- add a compact `REWARD UPDATE` notice to the Claim tab explaining that KTON staking will no longer earn new RING rewards while previously earned rewards remain claimable
- link the notice to the approved KtonDAO governance proposal
- keep the expanded Claim card usable on short screens and prevent the tab content from remaining hidden at initial render
- add a render-level regression test for the notice copy, KtonDAO proposal URL, and external-link accessibility attributes

## Verification

- `pnpm exec prettier --check 'src/app/(defi)/layout.tsx' 'src/app/(defi)/page.tsx' src/app/layout.tsx src/components/claim-rewards-notice.tsx src/components/claim-rewards-notice.test.tsx`
- `pnpm run test` — 4 tests passed
- `pnpm run lint`
- `pnpm run build` with Node.js v22.15.0
- desktop visual QA at 1065×795
- mobile visual QA at 390×844

## Proposal

https://gov.ktondao.xyz/proposal/0xb20b4feabca368f82aa819edce05e65a20d8ebbd998f0681143bbe6958052469

## Notes

The build completes successfully and retains the existing WalletConnect/MetaMask dependency warnings emitted by the current project setup.
